### PR TITLE
Return 404 on IP not found

### DIFF
--- a/apiserver/config.go
+++ b/apiserver/config.go
@@ -35,6 +35,7 @@ type Config struct {
 	ReadTimeout         time.Duration `envconfig:"READ_TIMEOUT"`
 	WriteTimeout        time.Duration `envconfig:"WRITE_TIMEOUT"`
 	PublicDir           string        `envconfig:"PUBLIC"`
+	FailOnIPNotFound    bool          `envconfig:"FAIL_ON_IP_NOTFOUND"`
 	DB                  string        `envconfig:"DB"`
 	UpdateInterval      time.Duration `envconfig:"UPDATE_INTERVAL"`
 	RetryInterval       time.Duration `envconfig:"RETRY_INTERVAL"`
@@ -114,6 +115,7 @@ func (c *Config) AddFlags(fs *flag.FlagSet) {
 	fs.DurationVar(&c.ReadTimeout, "read-timeout", c.ReadTimeout, "Read timeout for HTTP and HTTPS client conns")
 	fs.DurationVar(&c.WriteTimeout, "write-timeout", c.WriteTimeout, "Write timeout for HTTP and HTTPS client conns")
 	fs.StringVar(&c.PublicDir, "public", c.PublicDir, "Public directory to serve at the {prefix}/ endpoint")
+	fs.BoolVar(&c.FailOnIPNotFound, "fail-on-ip-notfound", c.UseXForwardedFor, "Fail request on ip not found")
 	fs.StringVar(&c.DB, "db", c.DB, "IP database file or URL")
 	fs.DurationVar(&c.UpdateInterval, "update", c.UpdateInterval, "Database update check interval")
 	fs.DurationVar(&c.RetryInterval, "retry", c.RetryInterval, "Max time to wait before retrying to download database")

--- a/db_test.go
+++ b/db_test.go
@@ -93,20 +93,20 @@ func TestNeedUpdateSameFile(t *testing.T) {
 }
 
 func TestNeedUpdateSameMD5(t *testing.T) {
-  db := &DB{file: testFile}
-  _, checksum, err := db.newReader(db.file)
-  if err != nil {
-    t.Fatal(err)
-  }
-  db.checksum = checksum
+	db := &DB{file: testFile}
+	_, checksum, err := db.newReader(db.file)
+	if err != nil {
+		t.Fatal(err)
+	}
+	db.checksum = checksum
 	mux := http.NewServeMux()
-  changeHeaderThenServe := func(h http.Handler) http.HandlerFunc {
-    return func(w http.ResponseWriter, r *http.Request) {
-      w.Header().Add("X-Database-MD5", checksum)
-      h.ServeHTTP(w, r)
-    }
-  }
-  mux.Handle("/testdata/", changeHeaderThenServe(http.FileServer(http.Dir("."))))
+	changeHeaderThenServe := func(h http.Handler) http.HandlerFunc {
+		return func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Add("X-Database-MD5", checksum)
+			h.ServeHTTP(w, r)
+		}
+	}
+	mux.Handle("/testdata/", changeHeaderThenServe(http.FileServer(http.Dir("."))))
 	srv := httptest.NewServer(mux)
 	defer srv.Close()
 	yes, err := db.needUpdate(srv.URL + "/" + testFile)
@@ -120,13 +120,13 @@ func TestNeedUpdateSameMD5(t *testing.T) {
 
 func TestNeedUpdateMD5(t *testing.T) {
 	mux := http.NewServeMux()
-  changeHeaderThenServe := func(h http.Handler) http.HandlerFunc {
-    return func(w http.ResponseWriter, r *http.Request) {
-      w.Header().Add("X-Database-MD5", "9823y5981y2398y1234")
-      h.ServeHTTP(w, r)
-    }
-  }
-  mux.Handle("/testdata/", changeHeaderThenServe(http.FileServer(http.Dir("."))))
+	changeHeaderThenServe := func(h http.Handler) http.HandlerFunc {
+		return func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Add("X-Database-MD5", "9823y5981y2398y1234")
+			h.ServeHTTP(w, r)
+		}
+	}
+	mux.Handle("/testdata/", changeHeaderThenServe(http.FileServer(http.Dir("."))))
 	srv := httptest.NewServer(mux)
 	defer srv.Close()
 	db := &DB{file: testFile}
@@ -327,5 +327,18 @@ func TestLookuUnavailable(t *testing.T) {
 	err := db.Lookup(net.ParseIP("8.8.8.8"), nil)
 	if err == nil {
 		t.Fatal("Unexpected lookup worked")
+	}
+}
+
+func TestLookupNotFound(t *testing.T) {
+	db, err := Open(testFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	var record DefaultQuery
+	err = db.Lookup(net.ParseIP("0.0.0.0"), &record)
+	if err != ErrNotFound {
+		t.Fatal("Unexpected error found: ", err)
 	}
 }


### PR DESCRIPTION
if the IP is not found on maxmind db, we get code 200 as response.

```
curl "http://freegeoip.net/json/0.0.0.0"
{"ip":"0.0.0.0","country_code":"","country_name":"","region_code":"","region_name":"","city":"","zip_code":"","time_zone":"","latitude":0,"longitude":0,"metro_code":0}
```
wouldn't it be better if it return 404 instead of 200?


This `PR` create a toggle `FAIL_ON_IP_NOTFOUND`, false by default to maintain retrocompatibility, and if it's true, return 404 on `IP not found`.
