### PR TITLE
feat: use default log Writer

### DIFF
--- a/apiserver/config.go
+++ b/apiserver/config.go
@@ -141,7 +141,7 @@ func (c *Config) logWriter() io.Writer {
 	if c.LogToStdout {
 		return os.Stdout
 	}
-	return os.Stderr
+	return log.Writer()
 }
 
 func (c *Config) errorLogger() *log.Logger {


### PR DESCRIPTION
This allows code that imports this module to override the log's writer.

It should have zero impact since the default Writer for `log` is `os.Stderr`.